### PR TITLE
Added property to indicate that the view is inside a Tabbar

### DIFF
--- a/KeyboardTrackingView.podspec
+++ b/KeyboardTrackingView.podspec
@@ -1,0 +1,19 @@
+require 'json'
+package = JSON.parse(File.read('./package.json'))
+
+Pod::Spec.new do |s|
+  s.name            = 'KeyboardTrackingView'
+  s.dependency        "React"
+
+  s.version         = package["version"]
+  s.license         = package["license"]
+  s.summary         = package["description"]
+  s.authors         = package["author"]
+  s.homepage        = package["homepage"]
+
+  s.platform        = :ios, "9.0"
+  s.requires_arc    = true
+
+  s.source          = { :git => s.homepage, :tag => s.version }
+  s.source_files    = "ios/**/*.{h,m}"
+end

--- a/KeyboardTrackingView.podspec
+++ b/KeyboardTrackingView.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
 
   s.source          = { :git => s.homepage, :tag => s.version }
-  s.source_files    = "ios/**/*.{h,m}"
+  s.source_files    = "lib/**/*.{h,m}"
 end

--- a/lib/KeyboardTrackingViewManager.m
+++ b/lib/KeyboardTrackingViewManager.m
@@ -501,12 +501,24 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
     });
 }
 
+-(CGFloat)getTabBarHeight {
+  UITabBarController *tabBarController = (UITabBarController *)[[[UIApplication sharedApplication] delegate] window].rootViewController;
+  CGFloat tabbarHeight = 0.0f;
+  
+  if (!tabBarController.tabBar.isHidden) {
+    tabbarHeight = tabBarController.tabBar.bounds.size.height;
+  }
+  
+  return tabbarHeight;
+}
+
 #pragma mark - ObservingInputAccessoryViewDelegate methods
 
 -(void)updateTransformAndInsets
 {
     CGFloat bottomSafeArea = [self getBottomSafeArea];
-    CGFloat accessoryTranslation = MIN(-bottomSafeArea, -_observingInputAccessoryView.keyboardHeight);
+    CGFloat tabBarHeight = [self getTabBarHeight];
+    CGFloat accessoryTranslation = MIN(-bottomSafeArea, -(_observingInputAccessoryView.keyboardHeight - tabBarHeight));
     
     if (_observingInputAccessoryView.keyboardHeight <= bottomSafeArea) {
         _bottomViewHeight = kBottomViewHeight;

--- a/lib/ObservingInputAccessoryView.m
+++ b/lib/ObservingInputAccessoryView.m
@@ -7,7 +7,6 @@
 //
 
 #import "ObservingInputAccessoryView.h"
-#import <React/RCTView.h>
 
 @implementation ObservingInputAccessoryViewManager
 
@@ -89,13 +88,7 @@
         CGFloat boundsH = self.superview.bounds.size.height;
         
         _previousKeyboardHeight = _keyboardHeight;
-		_keyboardHeight = MAX(0, self.window.bounds.size.height - (centerY - boundsH / 2) - self.intrinsicContentSize.height);
-
-        CGFloat bottomLayout = [self getBottomLayoutGuide];
-
-        if (bottomLayout) {
-          _keyboardHeight -= bottomLayout;
-        }
+        _keyboardHeight = MAX(0, self.window.bounds.size.height - (centerY - boundsH / 2) - self.intrinsicContentSize.height);
 
         [_delegate observingInputAccessoryViewDidChangeFrame:self];
 	}
@@ -171,30 +164,6 @@
     [_delegate observingInputAccessoryViewDidChangeFrame:self];
     
 	[self invalidateIntrinsicContentSize];
-}
-
-- (UIViewController *)reactViewController:(UIView *)view
-{
-  id responder = [view nextResponder];
-  while (responder) {
-    if ([responder isKindOfClass:[UIViewController class]]) {
-      if (((UIViewController*)responder).bottomLayoutGuide.length > 0) {
-        return responder;
-      }
-    }
-    responder = [responder nextResponder];
-  }
-  return nil;
-}
-
-- (CGFloat)getBottomLayoutGuide
-{
-  UIViewController *controller = [self reactViewController:self];
-  if (controller) {
-    return controller.bottomLayoutGuide.length;
-  }
-  
-  return 0;
 }
 
 @end

--- a/lib/ObservingInputAccessoryView.m
+++ b/lib/ObservingInputAccessoryView.m
@@ -7,6 +7,7 @@
 //
 
 #import "ObservingInputAccessoryView.h"
+#import <React/RCTView.h>
 
 @implementation ObservingInputAccessoryViewManager
 
@@ -89,7 +90,13 @@
         
         _previousKeyboardHeight = _keyboardHeight;
 		_keyboardHeight = MAX(0, self.window.bounds.size.height - (centerY - boundsH / 2) - self.intrinsicContentSize.height);
-		
+
+        CGFloat bottomLayout = [self getBottomLayoutGuide];
+
+        if (bottomLayout) {
+          _keyboardHeight -= bottomLayout;
+        }
+
         [_delegate observingInputAccessoryViewDidChangeFrame:self];
 	}
 }
@@ -164,6 +171,30 @@
     [_delegate observingInputAccessoryViewDidChangeFrame:self];
     
 	[self invalidateIntrinsicContentSize];
+}
+
+- (UIViewController *)reactViewController:(UIView *)view
+{
+  id responder = [view nextResponder];
+  while (responder) {
+    if ([responder isKindOfClass:[UIViewController class]]) {
+      if (((UIViewController*)responder).bottomLayoutGuide.length > 0) {
+        return responder;
+      }
+    }
+    responder = [responder nextResponder];
+  }
+  return nil;
+}
+
+- (CGFloat)getBottomLayoutGuide
+{
+  UIViewController *controller = [self reactViewController:self];
+  if (controller) {
+    return controller.bottomLayoutGuide.length;
+  }
+  
+  return 0;
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/wix/react-native-keyboard-tracking-view.git"
   },
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "React Native UI component which tracks the keyboard",
   "nativePackage": true,
   "bugs": {


### PR DESCRIPTION
I found that the tracking view was floating quite far away from the keyboard when my view was inside a tabbed view controller.
I added a property `viewIsInsideTabBar` to the view to indicate that the tracking view is inside a tabbar.