### PR TITLE
Add capability to use Cocoapods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A react native UI component that enables “keyboard tracking" for this view and
 	npm i react-native-keyboard-tracking-view --save
 	```
 
+#### Option: Manually
+
 - Locate the module lib folder in your node modules:
 	`PROJECT_DIR/node_modules/react-native-keyboard-tracking-view/lib`.
 
@@ -21,6 +23,15 @@ A react native UI component that enables “keyboard tracking" for this view and
 - Add `libKeyboardTrackingView.a` to your target's **Linked Frameworks and Libraries**.
 
 ![](https://github.com/wix/react-native-keyboard-tracking-view/blob/master/img/add_lib.png)
+
+#### Option: With [CocoaPods](https://cocoapods.org/)
+
+Add the following to your `Podfile` and run `pod update`:
+
+```
+pod 'react-native-keyboard-tracking-view', :path => '../node_modules/react-native-keyboard-tracking-view'
+```
+
 
 ## How To Use
 Require the native component:

--- a/react-native-keyboard-tracking-view.podspec
+++ b/react-native-keyboard-tracking-view.podspec
@@ -1,0 +1,17 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name                  = "react-native-keyboard-tracking-view"
+  s.version               = version
+  s.summary               = "Keyboard Tracking View for React Native."
+  s.homepage              = "https://github.com/wix/react-native-keyboard-tracking-view"
+  s.license               = 'MIT'
+  s.source                = { path: '.' }
+  s.ios.deployment_target = '9.0'
+  s.authors               = { 'Artal Druk' => 'artald@wix.com' }
+  s.source_files          = 'lib/*.{h,m}'
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
Adding a podspec allows the user to include this library using 
```
pod 'react-native-keyboard-tracking-view', :path => '../node_modules/react-native-keyboard-tracking-view'
```
rather than adding libraries manually. 