### PR TITLE
Fix react-native-keyboard-tracking-view when used in a mutli-page chat app

### DIFF
--- a/lib/KeyboardTrackingViewManager.m
+++ b/lib/KeyboardTrackingViewManager.m
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
                 {
                     _scrollViewToManage = ((RCTScrollView*)subview).scrollView;
                 }
-                else if([subview isKindOfClass:[UIScrollView class]])
+                else if(!_requiresSameParentToManageScrollView && [subview isKindOfClass:[UIScrollView class]])
                 {
                     _scrollViewToManage = (UIScrollView*)subview;
                 }


### PR DESCRIPTION
**Context**: You're building a chat app. It has multiple scrollviews. The first one is a list of people. When you tap on a person, it takes you to a messages page, where you can message that person.

**Problem**: `react-native-keyboard-tracking-view` chooses the first scrollview available. The first scrollview in this case is the list of people. But, if you were using `react-native-keyboard-input-view` and wanted to use it for an InputAccessoryView on the messages page, it will track the scrollview with the list of people, instead of the messages page.

**Solution**: `requiresSameParentToManageView` 

`requiresSameParentToManageView` already exists, however it has a bug.

When `requiresSameParentToManageScrollView` is `true`, we're asking `KeyboardTrackingViewManager` to ignore all scroll views that do not share a superview with the` <KeyboardTrackingView />`. This is a way to isolate a more specific scroll view to track, than simply the first one it finds.

The line after checking `requiresSameParentToManageScrollView` doesn't ensure that `requiresSameParentToManageScrollView` is false, meaning that if `requiresSameParentToManageScrollView` is `true`, and it finds a scrollview that isn't the parent superview...it will just use that one, defeating the purpose of `requiresSameParentToManageScrollView`.

This PR ensures that if `requiresSameParentToManageScrollView` is `true`,  it ignores scroll views that don't share a superview.

**Testing plan**

Manually. I verified in my app that it now chooses the parent scrollview, rather than the first scrollview found during the breadth-first search