### PR TITLE
Fixed iphone x gap caused by safe area at the bottom

### DIFF
--- a/lib/ObservingInputAccessoryView.m
+++ b/lib/ObservingInputAccessoryView.m
@@ -86,6 +86,7 @@
         }
         
         CGFloat bottomPadding = 0;
+        CGFloat boundsH = self.superview.bounds.size.height;
         
         if (@available(iOS 11.0, *)) {
             UIWindow *window = UIApplication.sharedApplication.keyWindow;

--- a/lib/ObservingInputAccessoryView.m
+++ b/lib/ObservingInputAccessoryView.m
@@ -85,10 +85,15 @@
             centerY = [change[NSKeyValueChangeNewKey] CGPointValue].y;
         }
         
-        CGFloat boundsH = self.superview.bounds.size.height;
+        CGFloat bottomPadding = 0;
+        
+        if (@available(iOS 11.0, *)) {
+            UIWindow *window = UIApplication.sharedApplication.keyWindow;
+            bottomPadding = window.safeAreaInsets.bottom;
+        }
         
         _previousKeyboardHeight = _keyboardHeight;
-		_keyboardHeight = MAX(0, self.window.bounds.size.height - (centerY - boundsH / 2) - self.intrinsicContentSize.height);
+		_keyboardHeight = MAX(0, self.window.bounds.size.height - (centerY - boundsH / 2) - self.intrinsicContentSize.height - bottomPadding);
 		
         [_delegate observingInputAccessoryViewDidChangeFrame:self];
 	}


### PR DESCRIPTION
Like in the issue: https://github.com/wix/react-native-keyboard-tracking-view/issues/17 