### PR TITLE
scrollIsInverted

### DIFF
--- a/lib/KeyboardTrackingViewManager.m
+++ b/lib/KeyboardTrackingViewManager.m
@@ -185,7 +185,7 @@ typedef NS_ENUM(NSUInteger, KeyboardTrackingScrollBehavior) {
                 
                 if(_scrollViewToManage != nil)
                 {
-                    _scrollIsInverted = CGAffineTransformEqualToTransform(_scrollViewToManage.superview.transform, CGAffineTransformMakeScale(1, -1));
+                    _scrollIsInverted = self.scrollIsInverted;
                 }
             }
             
@@ -629,6 +629,7 @@ RCT_EXPORT_MODULE()
 RCT_REMAP_VIEW_PROPERTY(scrollBehavior, scrollBehavior, KeyboardTrackingScrollBehavior)
 RCT_REMAP_VIEW_PROPERTY(revealKeyboardInteractive, revealKeyboardInteractive, BOOL)
 RCT_REMAP_VIEW_PROPERTY(manageScrollView, manageScrollView, BOOL)
+RCT_REMAP_VIEW_PROPERTY(scrollIsInverted, scrollIsInverted, BOOL)
 RCT_REMAP_VIEW_PROPERTY(requiresSameParentToManageScrollView, requiresSameParentToManageScrollView, BOOL)
 RCT_REMAP_VIEW_PROPERTY(addBottomView, addBottomView, BOOL)
 RCT_REMAP_VIEW_PROPERTY(scrollToFocusedInput, scrollToFocusedInput, BOOL)


### PR DESCRIPTION
There are a lot of problems when using sectionlist/flatlist inverted. The best way in my opinion is the user said in a prop like scrollIsInverted={true}